### PR TITLE
fix: Add cfg guard to cleanup_native_control for cross-platform compilation

### DIFF
--- a/crates/gpui/src/elements/native_element_helpers.rs
+++ b/crates/gpui/src/elements/native_element_helpers.rs
@@ -65,6 +65,7 @@ pub(super) fn schedule_native_focus_callback(
 ///
 /// # Safety
 /// Both pointers must be valid ObjC objects (or null for target_ptr).
+#[cfg(target_os = "macos")]
 pub(super) unsafe fn cleanup_native_control(
     control_ptr: *mut c_void,
     target_ptr: *mut c_void,


### PR DESCRIPTION
## Summary
- Adds `#[cfg(target_os = "macos")]` to `cleanup_native_control` in `native_element_helpers.rs`
- This function uses `cocoa::base::id` and `platform::native_controls` which are macOS-only

## Context
Without this guard, `cargo check` fails on Linux/Windows with unresolved import errors for `cocoa` and `native_controls`.

## Test plan
- [x] `cargo check -p gpui` passes on macOS
- [ ] CI passes (fmt, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)