### PR TITLE
Add native macOS toolbar component

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -329,6 +329,10 @@ name = "native_search_field"
 path = "examples/native_search_field.rs"
 
 [[example]]
+name = "native_toolbar"
+path = "examples/native_toolbar.rs"
+
+[[example]]
 name = "native_stepper"
 path = "examples/native_stepper.rs"
 

--- a/crates/gpui/examples/native_toolbar.rs
+++ b/crates/gpui/examples/native_toolbar.rs
@@ -1,0 +1,144 @@
+use gpui::{
+    App, Application, Bounds, Context, NativeToolbar, NativeToolbarButton, NativeToolbarClickEvent,
+    NativeToolbarDisplayMode, NativeToolbarItem, NativeToolbarSearchEvent,
+    NativeToolbarSearchField, NativeToolbarSizeMode, Window, WindowAppearance, WindowBounds,
+    WindowOptions, div, prelude::*, px, rgb, size,
+};
+
+struct NativeToolbarExample {
+    toolbar_installed: bool,
+    count: usize,
+    query: String,
+    submitted: String,
+    last_action: String,
+}
+
+impl Render for NativeToolbarExample {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !self.toolbar_installed {
+            window.set_native_toolbar(Some(
+                NativeToolbar::new("gpui.native.toolbar.example")
+                    .title("GPUI Native Toolbar")
+                    .display_mode(NativeToolbarDisplayMode::IconAndLabel)
+                    .size_mode(NativeToolbarSizeMode::Regular)
+                    .item(NativeToolbarItem::Button(
+                        NativeToolbarButton::new("increment", "Increment")
+                            .tool_tip("Increase the counter")
+                            .on_click(cx.listener(
+                                |this, event: &NativeToolbarClickEvent, _, cx| {
+                                    this.count += 1;
+                                    this.last_action = format!("clicked {}", event.item_id);
+                                    cx.notify();
+                                },
+                            )),
+                    ))
+                    .item(NativeToolbarItem::Button(
+                        NativeToolbarButton::new("reset", "Reset")
+                            .tool_tip("Reset the counter")
+                            .on_click(cx.listener(
+                                |this, event: &NativeToolbarClickEvent, _, cx| {
+                                    this.count = 0;
+                                    this.last_action = format!("clicked {}", event.item_id);
+                                    cx.notify();
+                                },
+                            )),
+                    ))
+                    .item(NativeToolbarItem::FlexibleSpace)
+                    .item(NativeToolbarItem::SearchField(
+                        NativeToolbarSearchField::new("toolbar_search")
+                            .placeholder("Search the example")
+                            .on_change(cx.listener(
+                                |this, event: &NativeToolbarSearchEvent, _, cx| {
+                                    this.query = event.text.clone();
+                                    this.last_action = format!("changed {}", event.item_id);
+                                    cx.notify();
+                                },
+                            ))
+                            .on_submit(cx.listener(
+                                |this, event: &NativeToolbarSearchEvent, _, cx| {
+                                    this.submitted = event.text.clone();
+                                    this.last_action = format!("submitted {}", event.item_id);
+                                    cx.notify();
+                                },
+                            )),
+                    )),
+            ));
+            self.toolbar_installed = true;
+        }
+
+        let is_dark = matches!(
+            window.appearance(),
+            WindowAppearance::Dark | WindowAppearance::VibrantDark
+        );
+
+        let (bg, fg, muted) = if is_dark {
+            (rgb(0x1c1f24), rgb(0xffffff), rgb(0xaeb7c2))
+        } else {
+            (rgb(0xf4f6fa), rgb(0x17202c), rgb(0x4f5d6d))
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .items_center()
+            .justify_center()
+            .gap_3()
+            .bg(bg)
+            .text_color(fg)
+            .child(div().text_xl().child("Native Toolbar Demo"))
+            .child(div().text_lg().child(format!("Count: {}", self.count)))
+            .child(div().text_sm().text_color(muted).child(format!(
+                "Live query: {}",
+                if self.query.is_empty() {
+                    "<empty>".to_string()
+                } else {
+                    self.query.clone()
+                }
+            )))
+            .child(div().text_sm().text_color(muted).child(format!(
+                "Submitted: {}",
+                if self.submitted.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    self.submitted.clone()
+                }
+            )))
+            .child(
+                div()
+                    .text_sm()
+                    .text_color(muted)
+                    .child(format!("Last action: {}", self.last_action)),
+            )
+            .child(
+                div()
+                    .text_sm()
+                    .text_color(muted)
+                    .child("Use toolbar buttons and search field above the content area."),
+            )
+    }
+}
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(780.0), px(460.0)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| {
+                cx.new(|_| NativeToolbarExample {
+                    toolbar_installed: false,
+                    count: 0,
+                    query: String::new(),
+                    submitted: String::new(),
+                    last_action: "<none>".to_string(),
+                })
+            },
+        )
+        .unwrap();
+
+        cx.activate(true);
+    });
+}

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -490,6 +490,56 @@ pub(crate) struct RequestFrameOptions {
     pub(crate) force_render: bool,
 }
 
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum PlatformNativeToolbarDisplayMode {
+    #[default]
+    Default,
+    IconAndLabel,
+    IconOnly,
+    LabelOnly,
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum PlatformNativeToolbarSizeMode {
+    #[default]
+    Default,
+    Regular,
+    Small,
+}
+
+pub(crate) struct PlatformNativeToolbar {
+    pub identifier: SharedString,
+    pub title: Option<SharedString>,
+    pub display_mode: PlatformNativeToolbarDisplayMode,
+    pub size_mode: PlatformNativeToolbarSizeMode,
+    pub shows_baseline_separator: bool,
+    pub items: Vec<PlatformNativeToolbarItem>,
+}
+
+pub(crate) enum PlatformNativeToolbarItem {
+    Button(PlatformNativeToolbarButtonItem),
+    Space,
+    FlexibleSpace,
+    SearchField(PlatformNativeToolbarSearchFieldItem),
+}
+
+pub(crate) struct PlatformNativeToolbarButtonItem {
+    pub id: SharedString,
+    pub label: SharedString,
+    pub tool_tip: Option<SharedString>,
+    pub on_click: Option<Box<dyn Fn()>>,
+}
+
+pub(crate) struct PlatformNativeToolbarSearchFieldItem {
+    pub id: SharedString,
+    pub placeholder: SharedString,
+    pub text: SharedString,
+    pub min_width: Pixels,
+    pub max_width: Pixels,
+    pub on_change: Option<Box<dyn Fn(String)>>,
+    pub on_submit: Option<Box<dyn Fn(String)>>,
+}
+
 pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn bounds(&self) -> Bounds<Pixels>;
     fn is_maximized(&self) -> bool;
@@ -558,6 +608,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn move_tab_to_new_window(&self) {}
     fn toggle_window_tab_overview(&self) {}
     fn set_tabbing_identifier(&self, _identifier: Option<String>) {}
+    fn set_native_toolbar(&self, _toolbar: Option<PlatformNativeToolbar>) {}
 
     #[cfg(target_os = "windows")]
     fn get_raw_handle(&self) -> windows::HWND;


### PR DESCRIPTION
## Summary
- Add native macOS toolbar (`NSToolbar`-based) component with platform layer and GPUI element API
- Implement toolbar item management, flexible space support, and window integration
- Add interactive example (`native_toolbar.rs`) demonstrating toolbar usage

## Changes
- `crates/gpui/src/platform/mac/window.rs` — NSToolbar ObjC integration in window layer
- `crates/gpui/src/platform.rs` — Platform trait additions for toolbar support
- `crates/gpui/src/window.rs` — Window-level toolbar API
- `crates/gpui/examples/native_toolbar.rs` — Example app
- `crates/gpui/Cargo.toml` — Example registration