### PR TITLE
Fix the Linux build broken by the gpui platform-crate extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ derive_refineable = { path = "crates/refineable/derive_refineable" }
 #
 
 anyhow = "1.0.86"
-ashpd = { version = "0.12.1", default-features = false, features = ["async-std"] }
+ashpd = { version = "0.13", default-features = false, features = ["async-io", "file_chooser", "open_uri", "settings"] }
 async-channel = "2.5.0"
 async-compression = { version = "0.4", features = ["bzip2", "gzip", "futures-io"] }
 async-fs = "2.1"

--- a/crates/gpui/src/platform/layer_shell.rs
+++ b/crates/gpui/src/platform/layer_shell.rs
@@ -62,3 +62,9 @@ pub struct LayerShellOptions {
     /// How keyboard focus should be handled.
     pub keyboard_interactivity: KeyboardInteractivity,
 }
+
+/// An error indicating that an action failed because the compositor doesn't
+/// support the required `zwlr_layer_shell_v1` protocol.
+#[derive(Debug, thiserror::Error)]
+#[error("Compositor doesn't support zwlr_layer_shell_v1")]
+pub struct LayerShellNotSupportedError;


### PR DESCRIPTION
Hi! I'm a hobbyist developer schmucking around with Rust GUIs for fun. I have a little library that embeds Servo in gpui ([wgpu-graft](https://github.com/mark-ik/wgpu-graft)), and I was testing it on Fedora 44 Workstation when I hit a Linux build break in `gpui_linux`. Tracked it down to two things the platform-crate extraction seems to have left behind:

**1. Stale `ashpd` pin.** `gpui_linux` is written against the ashpd 0.13 API:
- `ashpd::Uri` — `crates/gpui_linux/src/linux/platform.rs:368`, `:431`, `:633`
- `ashpd::desktop::file_chooser` — `platform.rs:342`, `:402`
- `ashpd::desktop::open_uri` — `platform.rs:662`, `:689`
- `ashpd::desktop::settings` — `crates/gpui_linux/src/linux/xdg_desktop_portal.rs:5`

…but the workspace pins ashpd 0.12.1 (`Cargo.toml:97`), where `ashpd::Uri` doesn't exist and the portal modules are laid out differently — so `gpui_linux` won't compile. Looks like the pin just didn't get bumped when the code moved to the 0.13 API?

**2. Missing `LayerShellNotSupportedError`.** `crates/gpui_linux/src/linux/wayland/window.rs:37` imports `gpui::layer_shell::LayerShellNotSupportedError` (used at `:142`), but the type isn't defined in `crates/gpui/src/platform/layer_shell.rs` anymore. It was in the pre-extraction monolith and looks like it didn't make the move.

Here's what I did to fix it:

`Cargo.toml` (workspace):
```diff
-ashpd = { version = "0.12.1", default-features = false, features = ["async-std"] }
+ashpd = { version = "0.13", default-features = false, features = ["async-io", "file_chooser", "open_uri", "settings"] }
```
(0.13 renamed the runtime feature `async-std` → `async-io` and gates each portal behind its own feature, hence the extra three.)

`crates/gpui/src/platform/layer_shell.rs` (re-add the type):
```rust
/// An error indicating that an action failed because the compositor doesn't
/// support the required `zwlr_layer_shell_v1` protocol.
#[derive(Debug, thiserror::Error)]
#[error("Compositor doesn't support zwlr_layer_shell_v1")]
pub struct LayerShellNotSupportedError;
```

With both, `gpui_linux` builds with `wayland,x11` and I get a real window rendering Servo on Fedora 44 (Mesa RADV, Vulkan). No new unit test since it's a build-breakage fix — the repro is just compiling `gpui_linux` on Linux.

Is this the right approach, or did you intend `gpui_linux` to stay on ashpd 0.12 (in which case the call sites are what's off)? What do y'all think?

Release Notes:

- Fixed the Linux build broken by the platform-crate extraction (ashpd 0.13 API + missing `LayerShellNotSupportedError`)
